### PR TITLE
feat(v0.10.0): Kalshi type state pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,23 +414,11 @@ dependencies = [
 
 [[package]]
 name = "kalshi"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "tokio",
- "uuid",
-]
-
-[[package]]
-name = "kalshi"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9effa6645fd9fb259f83892da9f697d50e044f20d399961c253d0285643102a"
-dependencies = [
- "reqwest",
- "serde",
  "tokio",
  "uuid",
 ]
@@ -778,7 +766,7 @@ version = "0.1.0"
 dependencies = [
  "dotenv",
  "futures",
- "kalshi 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kalshi",
  "tokio",
 ]
 

--- a/kalshi/Cargo.toml
+++ b/kalshi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kalshi"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["David Petre <david.petre31@gmail.com>"]
 edition = "2021"
 rust-version = "1.72"
@@ -22,8 +22,8 @@ doctest = false
 [dependencies]
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
-serde = { version = "1.0", features = ["derive"]}
-uuid = { version = "1.5.0", features = ["v4", "fast-rng"]}
+serde = { version = "1.0", features = ["derive"] }
+uuid = { version = "1.5.0", features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
 serde_json = "1.0.111"

--- a/kalshi/src/auth.rs
+++ b/kalshi/src/auth.rs
@@ -20,11 +20,7 @@ impl<'a> Kalshi<LoggedOut> {
     /// ```
     /// let kalshi_instance = kalshi_instance.login("johndoe@example.com", "example_password").await?;
     /// ```
-    pub async fn login(
-        &mut self,
-        user: &str,
-        password: &str,
-    ) -> Result<Kalshi<LoggedIn>, KalshiError> {
+    pub async fn login(self, user: &str, password: &str) -> Result<Kalshi<LoggedIn>, KalshiError> {
         let login_url: &str = &format!("{}/login", self.base_url);
 
         let login_payload = LoginPayload {

--- a/kalshi/src/auth.rs
+++ b/kalshi/src/auth.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use super::Kalshi;
 use crate::{kalshi_error::*, LoggedIn, LoggedOut};
 use serde::{Deserialize, Serialize};
@@ -43,15 +41,15 @@ impl<'a> Kalshi<LoggedOut> {
             .json()
             .await?;
 
-        self.curr_token = Some(format!("Bearer {}", result.token));
-        self.member_id = Some(result.member_id);
+        let logged_in = LoggedIn {
+            curr_token: format!("Bearer {}", result.token),
+            member_id: result.member_id,
+        };
 
         Ok(Kalshi {
             base_url: self.base_url.clone(),
-            curr_token: self.curr_token.clone(),
-            member_id: self.member_id.clone(),
             client: self.client.clone(),
-            state: PhantomData,
+            state: logged_in,
         })
     }
 }
@@ -75,17 +73,15 @@ impl<'a> Kalshi<LoggedIn> {
 
         self.client
             .post(logout_url)
-            .header("Authorization", self.curr_token.clone().unwrap())
+            .header("Authorization", self.state.curr_token.clone())
             .header("content-type", "application/json".to_string())
             .send()
             .await?;
 
         Ok(Kalshi {
             base_url: self.base_url.clone(),
-            curr_token: None,
-            member_id: None,
             client: self.client.clone(),
-            state: PhantomData,
+            state: LoggedOut,
         })
     }
 }

--- a/kalshi/src/exchange.rs
+++ b/kalshi/src/exchange.rs
@@ -2,7 +2,7 @@ use super::Kalshi;
 use crate::kalshi_error::*;
 use serde::{Deserialize, Serialize};
 
-impl Kalshi {
+impl<State> Kalshi<State> {
     /// Asynchronously retrieves the current status of the exchange.
     ///
     /// This function makes an HTTP GET request to the Kalshi exchange status endpoint
@@ -16,7 +16,7 @@ impl Kalshi {
     /// kalshi_instance.get_exchange_status().await.unwrap();
     /// ```
     pub async fn get_exchange_status(&self) -> Result<ExchangeStatus, KalshiError> {
-        let exchange_status_url: &str = &format!("{}/exchange/status", self.base_url.to_string());
+        let exchange_status_url: &str = &format!("{}/exchange/status", self.base_url);
 
         let result: ExchangeStatus = self
             .client
@@ -26,7 +26,7 @@ impl Kalshi {
             .json()
             .await?;
 
-        return Ok(result);
+        Ok(result)
     }
 
     /// Asynchronously retrieves the exchange's trading schedule.
@@ -42,8 +42,7 @@ impl Kalshi {
     /// kalshi_instance.get_exchange_schedule().await.unwrap();
     /// ```
     pub async fn get_exchange_schedule(&self) -> Result<ExchangeScheduleStandard, KalshiError> {
-        let exchange_schedule_url: &str =
-            &format!("{}/exchange/schedule", self.base_url.to_string());
+        let exchange_schedule_url: &str = &format!("{}/exchange/schedule", self.base_url);
 
         let result: ExchangeScheduleResponse = self
             .client
@@ -52,7 +51,7 @@ impl Kalshi {
             .await?
             .json()
             .await?;
-        return Ok(result.schedule);
+        Ok(result.schedule)
     }
 }
 

--- a/kalshi/src/lib.rs
+++ b/kalshi/src/lib.rs
@@ -35,11 +35,11 @@
 //!
 //! Initialize the Kalshi Struct and login using your authentication details:
 //! - **IMPORTANT**:  A user's authentication token expires every thirty minutes, this means
-//! that you'll need to call the login function every thirty minutes in order to
-//! ensure that you remain authenticated with a valid token.
+//!   that you'll need to call the login function every thirty minutes in order to
+//!   ensure that you remain authenticated with a valid token.
 //! - Storing user / password information in plaintext is not recommended,
-//! an implementation of extracting user details from local environmental variables
-//! is available [here](https://github.com/dpeachpeach/kalshi-rust/blob/main/sample_bot/src/main.rs#L12)
+//!   an implementation of extracting user details from local environmental variables
+//!   is available [here](https://github.com/dpeachpeach/kalshi-rust/blob/main/sample_bot/src/main.rs#L12)
 //! ```
 //! use kalshi::Kalshi;
 //! use kalshi::TradingEnvironment;
@@ -123,8 +123,6 @@ mod kalshi_error;
 mod market;
 mod portfolio;
 
-use std::marker::PhantomData;
-
 pub use exchange::*;
 pub use kalshi_error::*;
 pub use market::*;
@@ -134,7 +132,13 @@ pub use portfolio::*;
 pub struct LoggedOut;
 
 #[derive(Debug, Clone)]
-pub struct LoggedIn;
+pub struct LoggedIn {
+    /// - `curr_token`: A field for storing the current authentication token.
+    curr_token: String,
+    #[allow(dead_code)]
+    /// - `member_id`: A field for storing the member ID.
+    member_id: String,
+}
 
 /// The Kalshi struct is the core of the kalshi-crate. It acts as the interface
 /// between the user and the market, abstracting away the meat of requests
@@ -154,13 +158,10 @@ pub struct LoggedIn;
 pub struct Kalshi<State = LoggedOut> {
     /// - `base_url`: The base URL for the API, determined by the trading environment.
     base_url: String,
-    /// - `curr_token`: A field for storing the current authentication token.
-    curr_token: Option<String>,
-    /// - `member_id`: A field for storing the member ID.
-    member_id: Option<String>,
     /// - `client`: The HTTP client used for making requests to the marketplace.
     client: reqwest::Client,
-    state: PhantomData<State>,
+    /// - `state`: TODO
+    state: State,
 }
 
 impl Kalshi {
@@ -188,35 +189,9 @@ impl Kalshi {
     pub fn new(trading_env: TradingEnvironment) -> Kalshi<LoggedOut> {
         Kalshi {
             base_url: utils::build_base_url(trading_env).to_string(),
-            curr_token: None,
-            member_id: None,
             client: reqwest::Client::new(),
-            state: PhantomData,
+            state: LoggedOut,
         }
-    }
-
-    /// Retrieves the current user authentication token, if available.
-    ///
-    /// # Returns
-    ///
-    /// Returns an `Option<String>` containing the authentication token. If no token
-    /// is currently stored, it returns `None`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use kalshi::{Kalshi, TradingEnvironment};
-    /// let kalshi = Kalshi::new(TradingEnvironment::DemoMode);
-    /// let token = kalshi.get_user_token();
-    /// if let Some(t) = token {
-    ///     println!("Current token: {}", t);
-    /// } else {
-    ///     println!("No token found");
-    /// }
-    /// ```
-    ///
-    pub fn get_user_token(&self) -> Option<String> {
-        self.curr_token.clone()
     }
 }
 

--- a/kalshi/src/lib.rs
+++ b/kalshi/src/lib.rs
@@ -195,6 +195,27 @@ impl Kalshi {
     }
 }
 
+impl Kalshi<LoggedIn> {
+    /// Retrieves the current user authentication token.
+    ///
+    /// # Returns
+    ///
+    /// Returns a string representing the current user authentication token.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kalshi::{Kalshi, TradingEnvironment};
+    /// let kalshi_instance = kalshi_instance.login("johndoe@example.com", "example_password").await?;
+    /// let token = kalshi_instance.get_user_token();
+    /// println!("Current token: {}", token);
+    /// ```
+    ///
+    pub fn get_user_token(&self) -> String {
+        self.state.curr_token.clone()
+    }
+}
+
 // GENERAL ENUMS
 // -----------------------------------------------
 

--- a/kalshi/src/lib.rs
+++ b/kalshi/src/lib.rs
@@ -131,10 +131,9 @@ pub use market::*;
 pub use portfolio::*;
 
 #[derive(Debug, Clone)]
-
 pub struct LoggedOut;
-#[derive(Debug, Clone)]
 
+#[derive(Debug, Clone)]
 pub struct LoggedIn;
 
 /// The Kalshi struct is the core of the kalshi-crate. It acts as the interface

--- a/kalshi/src/lib.rs
+++ b/kalshi/src/lib.rs
@@ -160,7 +160,7 @@ pub struct Kalshi<State = LoggedOut> {
     base_url: String,
     /// - `client`: The HTTP client used for making requests to the marketplace.
     client: reqwest::Client,
-    /// - `state`: TODO
+    /// - `state`: The state of the Kalshi instance, either logged in or logged out.
     state: State,
 }
 

--- a/sample_bot/Cargo.toml
+++ b/sample_bot/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
-kalshi = { version = "0.10" }
+kalshi = { path = "../kalshi" }
 dotenv = "0.15"
 futures = "0.3"

--- a/sample_bot/Cargo.toml
+++ b/sample_bot/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1", features = ["full"]}
-kalshi = { version = "0.9"}
+tokio = { version = "1", features = ["full"] }
+kalshi = { version = "0.10" }
 dotenv = "0.15"
 futures = "0.3"

--- a/sample_bot/src/main.rs
+++ b/sample_bot/src/main.rs
@@ -41,20 +41,25 @@ fn retreive_credentials(setting: APIType) -> Result<(String, String), std::io::E
 async fn main() {
     dotenv().ok();
 
-    let (username, password) = retreive_credentials(APIType::Demo).unwrap() ;
+    let (username, password) = retreive_credentials(APIType::Demo).unwrap();
 
     let mut kalshi_instance = Kalshi::new(kalshi::TradingEnvironment::DemoMode);
 
-    kalshi_instance.login(&username, &password).await;
+    let kalshi_instance = kalshi_instance.login(&username, &password).await.unwrap();
 
     let new_york_ticker = "HIGHNY-23NOV13-T51".to_string();
 
-    let nytemp_market_data = kalshi_instance.get_single_market(&new_york_ticker).await.unwrap();
-    
-    let nytemp_market_orderbook = kalshi_instance.get_market_orderbook(&new_york_ticker, Some(1)).await.unwrap();
+    let nytemp_market_data = kalshi_instance
+        .get_single_market(&new_york_ticker)
+        .await
+        .unwrap();
 
+    let nytemp_market_orderbook = kalshi_instance
+        .get_market_orderbook(&new_york_ticker, Some(1))
+        .await
+        .unwrap();
 
-      let bought_order = kalshi_instance
+    let bought_order = kalshi_instance
         .create_order(
             kalshi::Action::Buy,
             None,
@@ -72,9 +77,7 @@ async fn main() {
         .unwrap();
 
     let ny_order_id = bought_order.order_id.clone();
-    
+
     let cancelled_order = kalshi_instance.cancel_order(&ny_order_id).await.unwrap();
     println!("{:?}", cancelled_order);
-
-    
 }

--- a/sample_bot/src/main.rs
+++ b/sample_bot/src/main.rs
@@ -46,8 +46,8 @@ async fn main() {
 
     let (username, password) = retreive_credentials(APIType::Demo).unwrap();
 
-    let mut kalshi_instance = Kalshi::new(kalshi::TradingEnvironment::DemoMode);
-    println!("{:?}", kalshi_instance);
+    let kalshi_instance = Kalshi::new(kalshi::TradingEnvironment::DemoMode);
+
     let kalshi_instance = kalshi_instance.login(&username, &password).await.unwrap();
 
     let new_york_ticker = "HIGHNY-23NOV13-T51".to_string();

--- a/sample_bot/src/main.rs
+++ b/sample_bot/src/main.rs
@@ -1,3 +1,6 @@
+// allow unused for the sake of the example
+#![allow(unused)]
+
 use dotenv::dotenv;
 use kalshi::Kalshi;
 use std::env;
@@ -44,7 +47,7 @@ async fn main() {
     let (username, password) = retreive_credentials(APIType::Demo).unwrap();
 
     let mut kalshi_instance = Kalshi::new(kalshi::TradingEnvironment::DemoMode);
-
+    println!("{:?}", kalshi_instance);
     let kalshi_instance = kalshi_instance.login(&username, &password).await.unwrap();
 
     let new_york_ticker = "HIGHNY-23NOV13-T51".to_string();


### PR DESCRIPTION
Initial implementation of the type state pattern for the `Kalshi` struct.

We could probably clean up the `Option<_>` fields on the `Kalshi`.

Also, not sure if I'm doing something wrong / if there is an easy fix, but, since the `sample_bot` crate depends on a published version of `kalshi`, it was impossible to update & run it based on my API changes.

We should also decide on v0.10.0 deliverables and open up a branch for development.